### PR TITLE
Add an accessibility label to emoji

### DIFF
--- a/Sources/MastodonMeta/MastodonMetaContent.swift
+++ b/Sources/MastodonMeta/MastodonMetaContent.swift
@@ -32,10 +32,11 @@ extension MastodonMetaContent: MetaContent {
     public var string: String { trimmed }
 
     public func metaAttachment(for entity: Meta.Entity) -> MetaAttachment? {
-        guard case let .emoji(text, _, url, _) = entity.meta else { return nil }
+        guard case let .emoji(text, shortcode, url, _) = entity.meta else { return nil }
 
         let imageView = SDAnimatedImageView()
         let attachment = MastodonMetaAttachment(string: text, url: url, content: imageView)
+        attachment.accessibilityLabel = shortcode
         return attachment
     }
 }


### PR DESCRIPTION
Tested locally and it seems to work ok! I’m not sure if we want to have it read as `:foo:`, `foo`, `:foo: emoji`, or `foo emoji` but I’m going with just `foo` (no punctuation) for now. Ideally it would follow the “Emoji Suffix” setting in the Settings app but I can’t find an API for that.