### PR TITLE
Set the Mastodon text attachment’s image to the full-size loaded image

### DIFF
--- a/Sources/MastodonMeta/MastodonMetaAttachment.swift
+++ b/Sources/MastodonMeta/MastodonMetaAttachment.swift
@@ -120,6 +120,8 @@ public class MastodonMetaAttachment: NSTextAttachment, MetaAttachment {
         imageView?.sd_setImage(with: URL(string: url)) { [weak self] image, error, cacheType, url in
             guard let self = self else { return }
             guard let image = image else { return }
+            self.image = image
+
             guard let totalFrameCount = self.imageView?.player?.totalFrameCount, totalFrameCount > 1
             else {
                 // resize transformer not works for APNG


### PR DESCRIPTION
This is a step towards unlocking text drag support in the Mastodon app (once updated to the latest MetaTextKit).