### PR TITLE
Fix text attachment handling bugs

### DIFF
--- a/Sources/MastodonMeta/MastodonMetaAttachment.swift
+++ b/Sources/MastodonMeta/MastodonMetaAttachment.swift
@@ -98,9 +98,6 @@ public class MastodonMetaAttachment: NSTextAttachment, MetaAttachment {
         self.content = content
         super.init(data: nil, ofType: UTType.image.identifier)
 
-        if #available(iOS 16, *) {
-            allowsTextAttachmentView = true
-        }
         image = MastodonMetaAttachment.placeholderImage
     }
     
@@ -108,14 +105,7 @@ public class MastodonMetaAttachment: NSTextAttachment, MetaAttachment {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public override func image(
-        for bounds: CGRect,
-        attributes: [NSAttributedString.Key : Any] = [:],
-        location: NSTextLocation,
-        textContainer: NSTextContainer?
-    ) -> UIImage? {
-        contentFrame = bounds
-
+    func prepareImageView(bounds: CGRect) {
         imageView?.contentMode = .scaleAspectFit
         imageView?.sd_setImage(with: URL(string: url)) { [weak self] image, error, cacheType, url in
             guard let self = self else { return }
@@ -130,6 +120,30 @@ public class MastodonMetaAttachment: NSTextAttachment, MetaAttachment {
                 return
             }
         }
+    }
+}
+
+class MastodonMetaAttachmentTextKit2: MastodonMetaAttachment {
+    override init(string: String, url: String, content: UIView) {
+        super.init(string: string, url: url, content: content)
+        if #available(iOS 16, *) {
+            allowsTextAttachmentView = true
+        }
+    }
+ 
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    public override func image(
+        for bounds: CGRect,
+        attributes: [NSAttributedString.Key : Any] = [:],
+        location: NSTextLocation,
+        textContainer: NSTextContainer?
+    ) -> UIImage? {
+        contentFrame = bounds
+        
+        prepareImageView(bounds: bounds)
         
         let image = super.image(for: bounds, attributes: attributes, location: location, textContainer: textContainer)
         return image
@@ -150,6 +164,15 @@ public class MastodonMetaAttachment: NSTextAttachment, MetaAttachment {
         self.viewProvider = viewProvider
         return viewProvider
     }
+}
 
+class MastodonMetaAttachmentTextKit1: MastodonMetaAttachment {
+    public override func image(forBounds imageBounds: CGRect, textContainer: NSTextContainer?, characterIndex charIndex: Int) -> UIImage? {
+        contentFrame = imageBounds
+        
+        prepareImageView(bounds: imageBounds)
+        let image = super.image(forBounds: imageBounds, textContainer: textContainer, characterIndex: charIndex)
+        return image
+    }
 }
 

--- a/Sources/MastodonMeta/MastodonMetaAttachment.swift
+++ b/Sources/MastodonMeta/MastodonMetaAttachment.swift
@@ -88,6 +88,8 @@ public class MastodonMetaAttachment: NSTextAttachment, MetaAttachment {
     public var contentFrame: CGRect = .zero
     public weak var viewProvider: NSTextAttachmentViewProvider?
 
+    private var loadedImageSize: CGSize? = nil
+    
     var imageView: SDAnimatedImageView? {
         return content as? SDAnimatedImageView
     }
@@ -106,6 +108,9 @@ public class MastodonMetaAttachment: NSTextAttachment, MetaAttachment {
     }
     
     func prepareImageView(bounds: CGRect) {
+        guard loadedImageSize != bounds.size else { return }
+        loadedImageSize = bounds.size
+
         imageView?.contentMode = .scaleAspectFit
         imageView?.sd_setImage(with: URL(string: url)) { [weak self] image, error, cacheType, url in
             guard let self = self else { return }

--- a/Sources/MastodonMeta/MastodonMetaContent.swift
+++ b/Sources/MastodonMeta/MastodonMetaContent.swift
@@ -31,12 +31,14 @@ public struct MastodonMetaContent {
 extension MastodonMetaContent: MetaContent {
     public var string: String { trimmed }
 
-    public func metaAttachment(for entity: Meta.Entity) -> MetaAttachment? {
+    public func metaAttachment(for entity: Meta.Entity, useTextKit2: Bool) -> MetaAttachment? {
         guard case let .emoji(text, _, url, _) = entity.meta else { return nil }
 
         let imageView = SDAnimatedImageView()
-        let attachment = MastodonMetaAttachment(string: text, url: url, content: imageView)
-        return attachment
+        if useTextKit2 {
+            return MastodonMetaAttachmentTextKit2(string: text, url: url, content: imageView)
+        }
+        return MastodonMetaAttachmentTextKit1(string: text, url: url, content: imageView)
     }
 }
 

--- a/Sources/Meta/MetaContent.swift
+++ b/Sources/Meta/MetaContent.swift
@@ -11,7 +11,7 @@ public protocol MetaContent {
     var string: String { get }
     var entities: [Meta.Entity] { get }
 
-    func metaAttachment(for entity: Meta.Entity) -> MetaAttachment?
+    func metaAttachment(for entity: Meta.Entity, useTextKit2: Bool) -> MetaAttachment?
 }
 
 extension MetaContent {

--- a/Sources/Meta/PlaintextMetaContent.swift
+++ b/Sources/Meta/PlaintextMetaContent.swift
@@ -15,7 +15,7 @@ public struct PlaintextMetaContent: MetaContent {
         self.string = string
     }
     
-    public func metaAttachment(for entity: Meta.Entity) -> MetaAttachment? {
+    public func metaAttachment(for entity: Meta.Entity, useTextKit2: Bool) -> MetaAttachment? {
         return nil
     }
 }

--- a/Sources/MetaLabel/MetaLabel.swift
+++ b/Sources/MetaLabel/MetaLabel.swift
@@ -98,7 +98,8 @@ extension MetaLabel {
             textAttributes: textAttributes,
             linkAttributes: linkAttributes,
             paragraphStyle: paragraphStyle,
-            content: content
+            content: content,
+            useTextKit2: true
         )
         
         textArea.configure(content: content)

--- a/Sources/MetaTextArea/MetaTextAreaView+MetaContent.swift
+++ b/Sources/MetaTextArea/MetaTextAreaView+MetaContent.swift
@@ -13,14 +13,21 @@ extension MetaTextAreaView {
     
     public func configure(content: MetaContent) {
         let attributedString = NSMutableAttributedString(string: content.string)
-        
+
+        let iOS16: Bool
+        if #available(iOS 16, *) {
+            iOS16 = true
+        } else {
+            iOS16 = false
+        }
+
         MetaText.setAttributes(
             for: attributedString,
                textAttributes: textAttributes,
                linkAttributes: linkAttributes,
                paragraphStyle: paragraphStyle,
             content: content,
-            useTextKit2: true
+            useTextKit2: iOS16
         )
         
         setAttributedString(attributedString)

--- a/Sources/MetaTextArea/MetaTextAreaView+MetaContent.swift
+++ b/Sources/MetaTextArea/MetaTextAreaView+MetaContent.swift
@@ -19,7 +19,8 @@ extension MetaTextAreaView {
                textAttributes: textAttributes,
                linkAttributes: linkAttributes,
                paragraphStyle: paragraphStyle,
-               content: content
+            content: content,
+            useTextKit2: true
         )
         
         setAttributedString(attributedString)

--- a/Sources/MetaTextKit/MetaText.swift
+++ b/Sources/MetaTextKit/MetaText.swift
@@ -80,6 +80,13 @@ extension MetaText {
 }
 
 extension MetaText {
+    private var useTextKit2: Bool {
+        if #available(iOS 16, *) {
+            return textView.textLayoutManager != nil
+        } else {
+            return false
+        }
+    }
 
     public func configure(content: MetaContent) {
         let attributedString = NSMutableAttributedString(string: content.string)
@@ -89,7 +96,8 @@ extension MetaText {
             textAttributes: textAttributes,
             linkAttributes: linkAttributes,
             paragraphStyle: paragraphStyle,
-            content: content
+            content: content,
+            useTextKit2: useTextKit2
         )
 
         textView.linkTextAttributes = linkAttributes
@@ -123,7 +131,8 @@ extension MetaText: MetaTextStorageDelegate {
             textAttributes: textAttributes,
             linkAttributes: linkAttributes,
             paragraphStyle: paragraphStyle,
-            content: content
+            content: content,
+            useTextKit2: useTextKit2
         )
         textStorage.endEditing()
 
@@ -139,7 +148,8 @@ extension MetaText {
         textAttributes: [NSAttributedString.Key: Any],
         linkAttributes: [NSAttributedString.Key: Any],
         paragraphStyle: NSMutableParagraphStyle,
-        content: MetaContent
+        content: MetaContent,
+        useTextKit2: Bool
     ) -> [MetaAttachment] {
 
         // clean up
@@ -173,12 +183,12 @@ extension MetaText {
         // attachment
         var replacedAttachments: [MetaAttachment] = []
         for entity in content.entities.reversed() {
-            guard let attachment = content.metaAttachment(for: entity) else { continue }
+            guard let attachment = content.metaAttachment(for: entity, useTextKit2: useTextKit2) else { continue }
             replacedAttachments.append(attachment)
 
             let font = attributedString.attribute(.font, at: entity.range.location, effectiveRange: nil) as? UIFont
             let fontSize = font?.pointSize ?? MetaText.fontSize
-            if #available(iOS 16, *) {
+            if useTextKit2 {
                 attachment.contentFrame = CGRect(
                     origin: .zero,
                     size: CGSize(width: fontSize, height: fontSize)

--- a/Sources/TwitterMeta/TwitterMetaContent.swift
+++ b/Sources/TwitterMeta/TwitterMetaContent.swift
@@ -17,7 +17,7 @@ public struct TwitterMetaContent {
 
 extension TwitterMetaContent: MetaContent {
     public var string: String { trimmed }
-    public func metaAttachment(for entity: Meta.Entity) -> MetaAttachment? {
+    public func metaAttachment(for entity: Meta.Entity, useTextKit2: Bool) -> MetaAttachment? {
         return nil
     }
 }

--- a/iOS Example/iOS Example/MastodonStatusViewController.swift
+++ b/iOS Example/iOS Example/MastodonStatusViewController.swift
@@ -237,12 +237,20 @@ extension MastodonStatusViewController {
                 return style
             }()
             
+            let iOS16: Bool
+            if #available(iOS 16, *) {
+                iOS16 = true
+            } else {
+                iOS16 = false
+            }
+            
             MetaText.setAttributes(
                 for: attributedString,
                    textAttributes: textAttributes,
                    linkAttributes: linkAttributes,
                    paragraphStyle: paragraphStyle,
-                   content: content
+                   content: content,
+                useTextKit2: iOS16
             )
             textView.textStorage.setAttributedString(attributedString)
         } catch {


### PR DESCRIPTION
`main` (e35b28b913762c7a9a6d1e36561a558376962a52), all visible emoji are animated:
<img width="600" alt="Screenshot_2023-01-11 16 34 00" src="https://user-images.githubusercontent.com/25517624/211922571-721e7b0d-3951-4e4b-ba77-6db95e0b38be.png">


This PR (all emoji are animated except for UITextView on iOS 15)
<img width="600" alt="Screenshot_2023-01-11 16 31 31" src="https://user-images.githubusercontent.com/25517624/211922135-5ec02d5c-7fd9-4018-a539-af03f12326db.png">
