### PR TITLE
[v2] Add support for newly supported inline formatting in MastodonMetaContent

### DIFF
--- a/Sources/MastodonMeta/MastodonMetaContent+Document.swift
+++ b/Sources/MastodonMeta/MastodonMetaContent+Document.swift
@@ -35,7 +35,7 @@ extension MastodonMetaContent {
                 let text = String(node.text)
                 let trimmed: String = {
                     if let hrefEllipsis = node.hrefEllipsis {
-                        return hrefEllipsis + "..."
+                        return hrefEllipsis + "…"
                     } else {
                         return text
                     }

--- a/Sources/MastodonMeta/MastodonMetaContent+Document.swift
+++ b/Sources/MastodonMeta/MastodonMetaContent+Document.swift
@@ -22,27 +22,27 @@ extension MastodonMetaContent {
             return document.trimmingCharacters(in: .whitespacesAndNewlines)
         }()
         let rootNode = try Node.parse(document: document)
-        let text = String(rootNode.text)
+        let rootText = String(rootNode.text)
 
         var metaEntities: [Meta.Entity] = []
         let metaNodes = MastodonMetaContent.Node.entities(in: rootNode)
         for node in metaNodes {
-            let range = NSRange(node.text.startIndex..<node.text.endIndex, in: text)
+            let range = NSRange(node.text.startIndex..<node.text.endIndex, in: rootText)
 
+            let nodeText = String(node.text)
             switch node.type {
             case .url:
                 guard let href = node.href else { continue }
-                let text = String(node.text)
                 let trimmed: String = {
                     if let hrefEllipsis = node.hrefEllipsis {
                         return hrefEllipsis + "…"
                     } else {
-                        return text
+                        return nodeText
                     }
                 }()
                 let entity = Meta.Entity(
                     range: range,
-                    meta: .url(text, trimmed: trimmed, url: href, userInfo: nil)
+                    meta: .url(nodeText, trimmed: trimmed, url: href, userInfo: nil)
                 )
                 metaEntities.append(entity)
             case .hashtag:
@@ -50,11 +50,10 @@ extension MastodonMetaContent {
                 node.href.flatMap { href in
                     userInfo["href"] = href
                 }
-                let string = String(node.text)
-                let hashtag = string.deletingPrefix("#")
+                let hashtag = nodeText.deletingPrefix("#")
                 let entity = Meta.Entity(
                     range: range,
-                    meta: .hashtag(string, hashtag: hashtag, userInfo: userInfo)
+                    meta: .hashtag(nodeText, hashtag: hashtag, userInfo: userInfo)
                 )
                 metaEntities.append(entity)
             case .mention:
@@ -62,11 +61,10 @@ extension MastodonMetaContent {
                 node.href.flatMap { href in
                     userInfo["href"] = href
                 }
-                let string = String(node.text)
-                let mention = string.deletingPrefix("@")
+                let mention = nodeText.deletingPrefix("@")
                 let entity = Meta.Entity(
                     range: range,
-                    meta: .mention(string, mention: mention, userInfo: userInfo)
+                    meta: .mention(nodeText, mention: mention, userInfo: userInfo)
                 )
                 metaEntities.append(entity)
             case .emoji:
@@ -78,16 +76,26 @@ extension MastodonMetaContent {
                     meta: .emoji(string, shortcode: shortcode, url: href, userInfo: nil)
                 )
                 metaEntities.append(entity)
+            case .formatted(.strong):
+                metaEntities.append(Meta.Entity(range: range, meta: .formatted(nodeText, .strong)))
+            case .formatted(.emphasized):
+                metaEntities.append(Meta.Entity(range: range, meta: .formatted(nodeText, .emphasized)))
+            case .formatted(.underlined):
+                metaEntities.append(Meta.Entity(range: range, meta: .formatted(nodeText, .underlined)))
+            case .formatted(.strikethrough):
+                metaEntities.append(Meta.Entity(range: range, meta: .formatted(nodeText, .strikethrough)))
+            case .formatted(.code):
+                metaEntities.append(Meta.Entity(range: range, meta: .formatted(nodeText, .code)))
             case .none:
                 continue
             }
         }
 
-        let trimmed = Meta.trim(content: text, orderedEntities: metaEntities)
+        let trimmed = Meta.trim(content: rootText, orderedEntities: metaEntities)
 
         return MastodonMetaContent(
             document: document,
-            original: text,
+            original: rootText,
             trimmed: trimmed,
             entities: metaEntities
         )

--- a/Sources/MastodonMeta/MastodonMetaContent+Node.swift
+++ b/Sources/MastodonMeta/MastodonMetaContent+Node.swift
@@ -44,7 +44,8 @@ extension MastodonMetaContent {
                 return Set(className.components(separatedBy: " "))
             }()
             let _type: Type? = {
-                if tagName == "a" {
+                switch tagName {
+                case "a":
                     if _classNames.contains("u-url") {
                         return .mention
                     }
@@ -52,7 +53,17 @@ extension MastodonMetaContent {
                         return .hashtag
                     }
                     return .url
-                } else {
+                case "b", "strong":
+                    return .formatted(.strong)
+                case "i", "em":
+                    return .formatted(.emphasized)
+                case "u":
+                    return .formatted(.underlined)
+                case "del":
+                    return .formatted(.strikethrough)
+                case "pre", "code":
+                    return .formatted(.code)
+                default:
                     if _classNames.contains("emoji") {
                         return .emoji
                     }
@@ -159,11 +170,25 @@ extension MastodonMetaContent {
 }
 
 extension MastodonMetaContent.Node {
-    enum `Type` {
+    enum `Type`: Equatable {
         case url
         case mention
         case hashtag
         case emoji
+        case formatted(FormatType)
+    }
+
+    enum FormatType: Equatable {
+        // b, strong
+        case strong
+        // i, em
+        case emphasized
+        // u
+        case underlined
+        // del
+        case strikethrough
+        // pre, code
+        case code
     }
 
     static func entities(in node: MastodonMetaContent.Node) -> [MastodonMetaContent.Node] {

--- a/Sources/Meta/Meta+Entity.swift
+++ b/Sources/Meta/Meta+Entity.swift
@@ -23,10 +23,11 @@ extension Meta.Entity {
     public var primaryText: String {
         switch self.meta {
         case .url(let text, _, _, _):      return text
-        case .emoji(let text, _, _, _):       return text
-        case .hashtag(let text, _, _):        return text
-        case .mention(let text, _, _):        return text
+        case .emoji(let text, _, _, _):    return text
+        case .hashtag(let text, _, _):     return text
+        case .mention(let text, _, _):     return text
         case .email(let text, _):          return text
+        case .formatted(let text, _):      return text
         }
     }
 }

--- a/Sources/Meta/Meta.swift
+++ b/Sources/Meta/Meta.swift
@@ -13,9 +13,18 @@ public enum Meta {
     case mention(_ text: String, mention: String, userInfo: [AnyHashable: Any]? = nil)
     case email(_ text: String, userInfo: [AnyHashable: Any]? = nil)
     case emoji(_ text: String, shortcode: String, url: String, userInfo: [AnyHashable: Any]? = nil)
+    case formatted(_ text: String, FormatType)
 }
 
 extension Meta {
+    
+    public enum FormatType {
+        case strong // e.g. bold
+        case emphasized // e.g. italic
+        case underlined
+        case strikethrough
+        case code
+    }
 
     public static func trim(content: String, orderedEntities: [Meta.Entity]) -> String {
         var content = content

--- a/Sources/MetaTextKit/MetaText.swift
+++ b/Sources/MetaTextKit/MetaText.swift
@@ -164,6 +164,10 @@ extension MetaText {
             range: NSRange(location: 0, length: attributedString.length)
         )
 
+
+        // paragraph
+        attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: allRange)
+
         // meta
         let stringRange = NSRange(location: 0, length: attributedString.length)
         for entity in content.entities {
@@ -203,6 +207,10 @@ extension MetaText {
                     if let monospaced = descriptor.withSymbolicTraits(descriptor.symbolicTraits.union(.traitMonoSpace)) {
                         attributedString.addAttribute(.font, value: UIFont(descriptor: monospaced, size: font.pointSize), range: entity.range)
                     }
+                    let paragraphStyle = paragraphStyle.mutableCopy() as! NSMutableParagraphStyle
+                    paragraphStyle.lineHeightMultiple = 1
+                    paragraphStyle.lineSpacing = 0
+                    attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: entity.range)
                 }
             }
         }
@@ -223,12 +231,9 @@ extension MetaText {
 
             // inject attachment via replace string at entity range
             attributedString.replaceCharacters(in: entity.range, with: NSAttributedString(attachment: attachment))
+            attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: entity.range)
         }
         allRange = NSRange(location: 0, length: attributedString.length)
-
-        // paragraph
-        // set after attachment to prevent paragraphStyle be replaced (e.g. attachment at the head of paragraph)
-        attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: allRange)
 
         return replacedAttachments
     }

--- a/Sources/MetaTextKit/MetaText.swift
+++ b/Sources/MetaTextKit/MetaText.swift
@@ -167,12 +167,44 @@ extension MetaText {
         // meta
         let stringRange = NSRange(location: 0, length: attributedString.length)
         for entity in content.entities {
-            var linkAttributes = linkAttributes
-            linkAttributes[.meta] = entity.meta
-            // FIXME: the emoji make cause wrong entity range out of bounds
-            // workaround: use intersection range temporary
-            let range = NSIntersectionRange(stringRange, entity.range)
-            attributedString.addAttributes(linkAttributes, range: range)
+            switch entity.meta {
+            case .url, .hashtag, .mention, .email, .emoji:
+                var linkAttributes = linkAttributes
+                linkAttributes[.meta] = entity.meta
+                // FIXME: the emoji make cause wrong entity range out of bounds
+                // workaround: use intersection range temporary
+                let range = NSIntersectionRange(stringRange, entity.range)
+                attributedString.addAttributes(linkAttributes, range: range)
+            case .formatted(_, let type):
+                attributedString.addAttribute(.meta, value: entity.meta, range: entity.range)
+                guard let font = attributedString.attribute(.font, at: entity.range.location, effectiveRange: nil) as? UIFont
+                else { continue }
+                let descriptor = font.fontDescriptor
+                switch type {
+                case .strong:
+                    if let bold = descriptor.withSymbolicTraits(descriptor.symbolicTraits.union(.traitBold)) {
+                        attributedString.addAttribute(.font, value: UIFont(descriptor: bold, size: font.pointSize), range: entity.range)
+                    }
+                case .emphasized:
+                    if let italic = descriptor.withSymbolicTraits(descriptor.symbolicTraits.union(.traitItalic)) {
+                        attributedString.addAttribute(.font, value: UIFont(descriptor: italic, size: font.pointSize), range: entity.range)
+                    }
+                case .underlined:
+                    attributedString.addAttribute(.underlineStyle, value: NSUnderlineStyle.single.rawValue, range: entity.range)
+                    if let underlineColor = textAttributes[.foregroundColor] as? UIColor {
+                        attributedString.addAttribute(.underlineColor, value: underlineColor, range: entity.range)
+                    }
+                case .strikethrough:
+                    attributedString.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: entity.range)
+                    if let strikethroughColor = textAttributes[.foregroundColor] as? UIColor {
+                        attributedString.addAttribute(.strikethroughColor, value: strikethroughColor, range: entity.range)
+                    }
+                case .code:
+                    if let monospaced = descriptor.withSymbolicTraits(descriptor.symbolicTraits.union(.traitMonoSpace)) {
+                        attributedString.addAttribute(.font, value: UIFont(descriptor: monospaced, size: font.pointSize), range: entity.range)
+                    }
+                }
+            }
         }
 
         // attachment

--- a/iOS Example/iOS Example/MastodonStatusViewController.swift
+++ b/iOS Example/iOS Example/MastodonStatusViewController.swift
@@ -124,7 +124,7 @@ extension MastodonStatusViewController {
     
     func setupStatusContent() {
         let content = """
-        <p>:sabakan: <a href=\"https://mastodon.social/tags/Mastodon\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>Mastodon</span></a> 3.5.3 has just been released with multiple security fixes, as well as a couple cool improvements!</p><p><a href=\"https://github.com/mastodon/mastodon/releases/tag/v3.5.3\" rel=\"nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://</span><span class=\"ellipsis\">github.com/mastodon/mastodon/r</span><span class=\"invisible\">eleases/tag/v3.5.3</span></a></p><p>A 3.4.8 backport is available for those who haven\'t made the jump to 3.5 yet.</p>
+        <p>:sabakan: <a href=\"https://mastodon.social/tags/Mastodon\" class=\"mention hashtag\" rel=\"nofollow noopener noreferrer\" target=\"_blank\">#<span>Mastodon</span></a> 3.5.3 has just been <em>released</em> with multiple <strong>security</strong> fixes, as well <strong>as a <em>couple</em> cool</strong> improvements!</p><p><a href=\"https://github.com/mastodon/mastodon/releases/tag/v3.5.3\" rel=\"nofollow noopener noreferrer\" target=\"_blank\"><span class=\"invisible\">https://</span><span class=\"ellipsis\">github.com/mastodon/mastodon/r</span><span class=\"invisible\">eleases/tag/v3.5.3</span></a></p><p>A 3.4.8 <code>backport</code>= is available <u>for</u> those who haven\'t made the <del>jump</del> to 3.5 yet.</p><pre><code>function helloWorld() {\n  console.log("Hello, world!");\n}</code></pre>
         """
         do {
             let metaContent = try MastodonMetaContent.convert(


### PR DESCRIPTION
Ref: https://github.com/mastodon/mastodon/pull/23913

- [x] `del`
- [x] `pre`, `code`
- [x] `b`, `strong`
- [x] `i`, `em`
- [x] `u`
- [x] `blockquote`
  - proper styling here to match the web version would require a vertical left border which is difficult to do with an attributed string (it requires inserting an attachment + custom rendering?
- [x] `ol`, `ul`, `li`
  - these require injecting marker text (e.g. “•” or “1.”) which is hard enough to be a separate PR

![image](https://github.com/TwidereProject/MetaTextKit/assets/25517624/52c21e62-c782-473c-ba2e-389e3e12de51)